### PR TITLE
Fix for node 10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "4.2"
+  - "6"
+  - "8"
+  - "10"
 sudo: false
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Add a empty function as callback to fs.unlink; fails without callback in Node 10.12
+
 ## [1.1.1] - 2016-06-08
 ### Fixed
 * Implement proper behavior on `readStream.end()`

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ Filesystem.prototype.createWriteStream = function (path, options) {
   const input = _()
   input.abort = function () {
     input.destroy()
-    fs.unlink(path)
+    fs.unlink(path, function () {})
   }
 
   input.end = function (chunk) {


### PR DESCRIPTION
* Add an empty function as callback to fs.unlink; fails without callback in Node 10.12.

* Update node versions in Travis.